### PR TITLE
Fixed attributes for unseal key

### DIFF
--- a/Chef/Cookbooks/Relativity/attributes/default.rb
+++ b/Chef/Cookbooks/Relativity/attributes/default.rb
@@ -70,9 +70,9 @@ default['secret_store']['install']['client']['location'] = 'C:\\\"Program Files\
 default['secret_store']['service']['port'] = '9090'
 default['secret_store']['init_result'] = 'C:\\\"Program Files\"\\\"Relativity Secret Store\"\\Client\\init_output.txt'
 default['secret_store']['unseal_key_identifier'] = 'UNSEALKEY'
-default['secret_store']['unseal_key'] = 'C:\\Program Files\\Relativity Secret Store\\unseal.txt'
-# default['secret_store']['unseal_key']['save_to_local_file_destination_folder'] = 'C:\\Relativity_Secret_Store_Unseal_Key'
-# default['secret_store']['unseal_key']['save_to_local_file_destination_path'] = "#{default['secret_store']['unseal_key']['save_to_local_file_destination_folder']}\\relativity_secret_store_unseal_key.txt"
+default['secret_store']['unseal_key']['original_unseal_key'] = "C:\\Program Files\\Relativity Secret Store\\unseal.txt"
+default['secret_store']['unseal_key']['save_to_local_file_destination_folder'] = "C:\\Relativity_Secret_Store_Unseal_Key"
+default['secret_store']['unseal_key']['save_to_local_file_destination_path'] = "#{default['secret_store']['unseal_key']['save_to_local_file_destination_folder']}\\relativity_secret_store_unseal_key.txt"
 
 default['relativity']['install']['source_folder'] = '\\\\kcura.corp\\shares\\Development\\DevEx\\DevVm\\Development\\Chandra\\DevVm_Install_Files\\Relativity'
 default['relativity']['install']['destination_folder'] = "#{default['file']['installers']['default_destination_folder']}\\Relativity"

--- a/Chef/Cookbooks/Relativity/recipes/pre_relativity_secret_store_install_save_secret_store_unseal_key_to_local_file.rb
+++ b/Chef/Cookbooks/Relativity/recipes/pre_relativity_secret_store_install_save_secret_store_unseal_key_to_local_file.rb
@@ -2,7 +2,7 @@ custom_log 'custom_log' do msg 'Saving Secret Store unseal key file' end
 start_time = DateTime.now
 custom_log 'custom_log' do msg "recipe_start_time(#{recipe_name}): #{start_time}" end
 
-file_source = node['secret_store']['unseal_key']
+file_source = node['secret_store']['unseal_key']['original_unseal_key']
 file_destination = node['secret_store']['unseal_key']['save_to_local_file_destination_path']
 file_destination_folder = node['secret_store']['unseal_key']['save_to_local_file_destination_folder']
 


### PR DESCRIPTION
Something to learn about attributes in chef

https://stackoverflow.com/questions/28200483/chef-error-on-attributes-string-not-matched

can't do this
*default['test']['webservice']['https']['keyManagerPwd'] = 'password'*
*default['test']['webservice']['https']['keyManagerPwd']['type'] = 'encrypted'*

where the chain is the same except for the end, as it treats it like this
*foo = "password"*
*foo['type'] = "encrypted"*