### PR TITLE
Rel 507461 removing rsapi from smoketesthelper

### DIFF
--- a/CSharp/DevVmPowershell/DevVmPsModules/Cmdlets/WaitForSmokeTestToFinishModule.cs
+++ b/CSharp/DevVmPowershell/DevVmPsModules/Cmdlets/WaitForSmokeTestToFinishModule.cs
@@ -79,10 +79,15 @@ namespace DevVmPsModules.Cmdlets
 				relativityAdminPassword: RelativityAdminPassword,
 				sqlAdminUserName: SqlAdminUserName,
 				sqlAdminPassword: SqlAdminPassword);
-			ISmokeTestHelper smokeTestHelper = new SmokeTestHelper(connectionHelper);
+			ISqlRunner sqlRunner = new SqlRunner(connectionHelper);
+			ISqlHelper sqlHelper = new SqlHelper(sqlRunner);
+			IRestHelper restHelper = new RestHelper();
+			IWorkspaceHelper workspaceHelper = new WorkspaceHelper(connectionHelper, restHelper, sqlHelper, RelativityInstanceName, RelativityAdminUserName, RelativityAdminPassword);
+			IRetryLogicHelper retryLogicHelper = new RetryLogicHelper();
+			ISmokeTestHelper smokeTestHelper = new SmokeTestHelper(connectionHelper, restHelper, retryLogicHelper, workspaceHelper, RelativityInstanceName, RelativityAdminUserName, RelativityAdminPassword);
 
 			int timeoutValueInMinutes = int.Parse(TimeoutValueInMinutes);
-			bool testsCompleted = smokeTestHelper.WaitForSmokeTestToComplete(WorkspaceName, timeoutValueInMinutes);
+			bool testsCompleted = smokeTestHelper.WaitForSmokeTestToCompleteAsync(WorkspaceName, timeoutValueInMinutes).Result;
 			if (!testsCompleted)
 			{
 				throw new Exception("Tests did not all complete successfully");

--- a/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
+++ b/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
@@ -60,7 +60,7 @@ namespace Helpers.Tests.Integration.Tests
 			{
 				//Arrange
 
-				//Delete Workspace with Disclaimer Acceptance Installed
+				//Delete Workspace with Smoke Test Installed
 				List<int> workspacesWhereApplicationIsInstalled = SqlHelper.RetrieveWorkspacesWhereApplicationIsInstalled(new Guid(Constants.SmokeTest.Guids.ApplicationGuid));
 				if (workspacesWhereApplicationIsInstalled.Count > 0)
 				{

--- a/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
+++ b/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
@@ -103,7 +103,7 @@ namespace Helpers.Tests.Integration.Tests
 				}
 
 				//Act
-				bool result = await Sut.WaitForSmokeTestToCompleteAsync(workspaceName, 10);
+				bool result = await Sut.WaitForSmokeTestToCompleteAsync(workspaceName, Constants.Waiting.SMOKE_TEST_HELPER_MAX_WAIT_TIME_IN_MINUTES);
 
 				//Assert
 				Assert.IsTrue(result);

--- a/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
+++ b/CSharp/DevVmPowershell/Helpers.Tests.Integration/Tests/SmokeTestHelperTests.cs
@@ -36,7 +36,8 @@ namespace Helpers.Tests.Integration.Tests
 			AgentHelper = new AgentHelper(connectionHelper, restHelper, TestConstants.RELATIVITY_INSTANCE_NAME, TestConstants.RELATIVITY_ADMIN_USER_NAME, TestConstants.RELATIVITY_ADMIN_PASSWORD);
 
 			ImportApiHelper = new ImportApiHelper(connectionHelper, TestConstants.RELATIVITY_INSTANCE_NAME, TestConstants.RELATIVITY_ADMIN_USER_NAME, TestConstants.RELATIVITY_ADMIN_PASSWORD);
-			Sut = new SmokeTestHelper(connectionHelper);
+			Sut = new SmokeTestHelper(connectionHelper, restHelper, RetryLogicHelper, WorkspaceHelper, TestConstants.RELATIVITY_INSTANCE_NAME,
+				TestConstants.RELATIVITY_ADMIN_USER_NAME, TestConstants.RELATIVITY_ADMIN_PASSWORD);
 		}
 
 		[TearDown]
@@ -102,7 +103,7 @@ namespace Helpers.Tests.Integration.Tests
 				}
 
 				//Act
-				bool result = Sut.WaitForSmokeTestToComplete(workspaceName, 10);
+				bool result = await Sut.WaitForSmokeTestToCompleteAsync(workspaceName, 10);
 
 				//Assert
 				Assert.IsTrue(result);

--- a/CSharp/DevVmPowershell/Helpers/Constants.cs
+++ b/CSharp/DevVmPowershell/Helpers/Constants.cs
@@ -391,6 +391,11 @@ END
 
 		public class SmokeTest
 		{
+			public class ObjectNames
+			{
+				public const string SmokeTestApplicationName = "Smoke Test";
+				public const string SmokeTestApplicationObjectTypeName = "Test";
+			}
 			public class Guids
 			{
 				public const string ApplicationGuid = "0125C8D4-8354-4D8F-B031-01E73C866C7C";

--- a/CSharp/DevVmPowershell/Helpers/Constants.cs
+++ b/CSharp/DevVmPowershell/Helpers/Constants.cs
@@ -78,8 +78,9 @@ namespace Helpers
 
 		public class Waiting
 		{
-			public const int MAX_WAIT_TIME_IN_MINUTES = 10;
-			public const int SLEEP_TIME_IN_SECONDS = 15;
+			public const int SMOKE_TEST_HELPER_MAX_WAIT_TIME_IN_MINUTES = 10;
+			public const int SMOKE_TEST_HELPER_SLEEP_TIME_IN_SECONDS = 10;
+			public const int SMOKE_TEST_HELPER_RETRY_COUNT = 10;
 			public const int IMAGING_HELPER_RETRY_COUNT = 60;
 			public const int IMAGING_HELPER_RETRY_DELAY = 10;
 		}

--- a/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
+++ b/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
@@ -1,6 +1,5 @@
 ﻿using Helpers.Interfaces;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Relativity.Services.ServiceProxy;
 using System;
 using System.Net.Http;
@@ -29,86 +28,61 @@ namespace Helpers.Implementations
 			AdminPassword = adminPassword;
 		}
 
-		//public async Task<bool> WaitForSmokeTestToCompleteAsync(string workspaceName, int timeoutValueInMinutes)
-		//{
-		//	try
-		//	{
-		//		bool completed = false;
-		//		bool hasFailingTests = false;
-		//		int maxTimeInMilliseconds = timeoutValueInMinutes * 60 * 1000;
-		//		const int sleepTimeInMilliSeconds = Constants.Waiting.SLEEP_TIME_IN_SECONDS * 1000;
-		//		int currentWaitTimeInMilliseconds = 0;
-
-		//		Console.WriteLine("Querying for Workspace Artifact Id");
-		//		int workspaceArtifactId = await WorkspaceHelper.GetFirstWorkspaceArtifactIdQueryAsync(workspaceName);
-		//		Console.WriteLine("Queried for Workspace Artifact Id");
-
-		//		while (currentWaitTimeInMilliseconds < maxTimeInMilliseconds && completed == false)
-		//		{
-		//			Thread.Sleep(sleepTimeInMilliSeconds);
-
-		//			Console.WriteLine("Querying for Smoke Test RDOs");
-		//			var queryResultSet = QueryForTestRDOs(workspaceArtifactId);
-		//			Console.WriteLine("Queried for Smoke Test RDOs");
-
-		//			int numberSuccess = 0;
-		//			int numberFail = 0;
-		//			foreach (Result<RDO> result in queryResultSet.Results)
-		//			{
-		//				string status = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)).ValueAsFixedLengthText;
-		//				if (status.Contains("Success"))
-		//				{
-		//					numberSuccess++;
-		//				}
-		//				if (status.Contains("Fail"))
-		//				{
-		//					numberFail++;
-		//					hasFailingTests = true;
-		//					completed = true;
-		//					string testName = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)).ValueAsFixedLengthText;
-		//					string errorDetails = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText)).ValueAsLongText;
-		//					Console.WriteLine($"Failing Test Found: {testName}");
-		//					Console.WriteLine($"Error Details: {errorDetails}");
-		//					break;
-		//				}
-		//			}
-
-		//			if (queryResultSet.Results.Count > 0)
-		//			{
-		//				if ((numberSuccess + numberFail) == queryResultSet.Results.Count)
-		//				{
-		//					completed = true;
-		//				}
-		//			}
-
-		//			currentWaitTimeInMilliseconds += sleepTimeInMilliSeconds;
-		//		}
-		//		//}
-
-		//		return completed && !hasFailingTests;
-		//	}
-		//	catch (Exception ex)
-		//	{
-		//		throw new Exception("An error occurred Waiting for the Smoke Test to Complete", ex);
-		//	}
-		//}
-
 		public async Task<bool> WaitForSmokeTestToCompleteAsync(string workspaceName, int timeoutValueInMinutes)
 		{
 			try
 			{
 				int workspaceId = await WorkspaceHelper.GetFirstWorkspaceArtifactIdQueryAsync(workspaceName);
-				int smokeTestObjectTypeId = await GetSmokeTestObjectTypeIdAsync(workspaceId);
+				int smokeTestObjectTypeId = await RetryLogicHelper.RetryFunctionAsync<int>(2, 30,
+					async () => await GetSmokeTestObjectTypeIdAsync(workspaceId));
 
-				HttpResponseMessage queryResponse = await QueryForSmokeTestRdos(workspaceId, smokeTestObjectTypeId);
+				bool didTestsComplete = await RetryLogicHelper.RetryFunctionAsync<bool>(10, timeoutValueInMinutes * 60,
+					async () =>
+					{
+						HttpResponseMessage queryResponse = await QueryForSmokeTestRdosAsync(workspaceId, smokeTestObjectTypeId);
 
-				string resultString = await queryResponse.Content.ReadAsStringAsync();
-				dynamic result = JObject.Parse(resultString) as JObject;
-				//objectTypeId = result.Objects[0]["Values"][1];
+						string resultString = await queryResponse.Content.ReadAsStringAsync();
+						dynamic queryResult = JsonConvert.DeserializeObject<dynamic>(resultString);
 
-				var test = result.Objects;
+						int totalTests = queryResult.TotalCount;
+						int numberSuccess = 0;
+						int numberFail = 0;
+						bool completed = false;
+						bool hasFailingTests = false;
 
-				return test != null;
+						foreach (var test in queryResult.Objects)
+						{
+							string status = test.Values[1];
+							if (status.Contains("Success"))
+							{
+								numberSuccess++;
+							}
+							if (status.Contains("Fail"))
+							{
+								numberFail++;
+								hasFailingTests = true;
+								completed = true;
+								string testName = test.Values[0];
+								string errorDetails = test.Values[3];
+								Console.WriteLine($"Failing Test Found: {testName}");
+								Console.WriteLine($"Error Details: {errorDetails}");
+								break;
+							}
+						}
+
+						if ((numberSuccess + numberFail) == totalTests && totalTests > 0)
+						{
+							completed = true;
+						}
+						else if (!completed)
+						{
+							throw new Exception("Smoke tests are not yet completed.");
+						}
+
+						return completed && !hasFailingTests;
+					});
+
+				return didTestsComplete;
 			}
 			catch (Exception ex)
 			{
@@ -161,28 +135,7 @@ namespace Helpers.Implementations
 			return objectTypeId;
 		}
 
-		//private QueryResultSet<RDO> QueryForTestRDOs(int workspaceArtifactId)
-		//{
-		//	Query<RDO> query = new Query<RDO>();
-		//	query.ArtifactTypeGuid = new Guid(Constants.SmokeTest.Guids.TestObjectType);
-		//	query.Fields = new List<FieldValue>
-		//	{
-		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)),
-		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)),
-		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Error_LongText)),
-		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText))
-		//	};
-
-		//	QueryResultSet<RDO> queryResultSet = rsapiClient.Repositories.RDO.Query(query);
-		//	if (!queryResultSet.Success)
-		//	{
-		//		throw new Exception("Unable to query for Smoke Test Test Objects");
-		//	}
-
-		//	return queryResultSet;
-		//}
-
-		private async Task<HttpResponseMessage> QueryForSmokeTestRdos(int workspaceId, int smokeTestObjectTypeId)
+		private async Task<HttpResponseMessage> QueryForSmokeTestRdosAsync(int workspaceId, int smokeTestObjectTypeId)
 		{
 			string url = Constants.Connection.RestUrlEndpoints.ObjectManager.QuerySlimUrl.Replace("-1", workspaceId.ToString());
 			HttpClient httpClient = RestHelper.GetHttpClient(InstanceAddress, AdminUsername, AdminPassword);
@@ -192,11 +145,8 @@ namespace Helpers.Implementations
 				request = new
 				{
 					objectType = new { Guid = Constants.SmokeTest.Guids.TestObjectType },
-					//objectType = new { artifactTypeId = Constants.OBJECT_TYPE_TYPE_ARTIFACT_ID },
-					//objectType = new { artifactTypeId = smokeTestObjectTypeId },
 					fields = new[]
 					{
-						//new { Name = "Name" },
 						new { Guid = Constants.SmokeTest.Guids.Fields.Name_FixedLengthText },
 						new { Guid = Constants.SmokeTest.Guids.Fields.Status_FixedLengthText },
 						new { Guid = Constants.SmokeTest.Guids.Fields.Error_LongText },

--- a/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
+++ b/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
@@ -1,82 +1,114 @@
 ﻿using Helpers.Interfaces;
-using kCura.Relativity.Client;
-using kCura.Relativity.Client.DTOs;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Relativity.Services.ServiceProxy;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Helpers.Implementations
 {
 	public class SmokeTestHelper : ISmokeTestHelper
 	{
 		private ServiceFactory ServiceFactory { get; }
-		public SmokeTestHelper(IConnectionHelper connectionHelper)
+		private IRestHelper RestHelper { get; }
+		private IRetryLogicHelper RetryLogicHelper { get; }
+		private IWorkspaceHelper WorkspaceHelper { get; }
+		private string InstanceAddress { get; }
+		private string AdminUsername { get; }
+		private string AdminPassword { get; }
+
+		public SmokeTestHelper(IConnectionHelper connectionHelper, IRestHelper restHelper, IRetryLogicHelper retryLogicHelper, IWorkspaceHelper workspaceHelper, string instanceAddress, string adminUsername, string adminPassword)
 		{
 			ServiceFactory = connectionHelper.GetServiceFactory();
+			RestHelper = restHelper;
+			RetryLogicHelper = retryLogicHelper;
+			WorkspaceHelper = workspaceHelper;
+			InstanceAddress = instanceAddress;
+			AdminUsername = adminUsername;
+			AdminPassword = adminPassword;
 		}
 
-		public bool WaitForSmokeTestToComplete(string workspaceName, int timeoutValueInMinutes)
+		//public async Task<bool> WaitForSmokeTestToCompleteAsync(string workspaceName, int timeoutValueInMinutes)
+		//{
+		//	try
+		//	{
+		//		bool completed = false;
+		//		bool hasFailingTests = false;
+		//		int maxTimeInMilliseconds = timeoutValueInMinutes * 60 * 1000;
+		//		const int sleepTimeInMilliSeconds = Constants.Waiting.SLEEP_TIME_IN_SECONDS * 1000;
+		//		int currentWaitTimeInMilliseconds = 0;
+
+		//		Console.WriteLine("Querying for Workspace Artifact Id");
+		//		int workspaceArtifactId = await WorkspaceHelper.GetFirstWorkspaceArtifactIdQueryAsync(workspaceName);
+		//		Console.WriteLine("Queried for Workspace Artifact Id");
+
+		//		while (currentWaitTimeInMilliseconds < maxTimeInMilliseconds && completed == false)
+		//		{
+		//			Thread.Sleep(sleepTimeInMilliSeconds);
+
+		//			Console.WriteLine("Querying for Smoke Test RDOs");
+		//			var queryResultSet = QueryForTestRDOs(workspaceArtifactId);
+		//			Console.WriteLine("Queried for Smoke Test RDOs");
+
+		//			int numberSuccess = 0;
+		//			int numberFail = 0;
+		//			foreach (Result<RDO> result in queryResultSet.Results)
+		//			{
+		//				string status = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)).ValueAsFixedLengthText;
+		//				if (status.Contains("Success"))
+		//				{
+		//					numberSuccess++;
+		//				}
+		//				if (status.Contains("Fail"))
+		//				{
+		//					numberFail++;
+		//					hasFailingTests = true;
+		//					completed = true;
+		//					string testName = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)).ValueAsFixedLengthText;
+		//					string errorDetails = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText)).ValueAsLongText;
+		//					Console.WriteLine($"Failing Test Found: {testName}");
+		//					Console.WriteLine($"Error Details: {errorDetails}");
+		//					break;
+		//				}
+		//			}
+
+		//			if (queryResultSet.Results.Count > 0)
+		//			{
+		//				if ((numberSuccess + numberFail) == queryResultSet.Results.Count)
+		//				{
+		//					completed = true;
+		//				}
+		//			}
+
+		//			currentWaitTimeInMilliseconds += sleepTimeInMilliSeconds;
+		//		}
+		//		//}
+
+		//		return completed && !hasFailingTests;
+		//	}
+		//	catch (Exception ex)
+		//	{
+		//		throw new Exception("An error occurred Waiting for the Smoke Test to Complete", ex);
+		//	}
+		//}
+
+		public async Task<bool> WaitForSmokeTestToCompleteAsync(string workspaceName, int timeoutValueInMinutes)
 		{
 			try
 			{
-				bool completed = false;
-				bool hasFailingTests = false;
-				int maxTimeInMilliseconds = timeoutValueInMinutes * 60 * 1000;
-				const int sleepTimeInMilliSeconds = Constants.Waiting.SLEEP_TIME_IN_SECONDS * 1000;
-				int currentWaitTimeInMilliseconds = 0;
-				using (IRSAPIClient rsapiClient = ServiceFactory.CreateProxy<IRSAPIClient>())
-				{
-					rsapiClient.APIOptions.WorkspaceID = -1;
-					Console.WriteLine("Querying for Workspace Artifact Id");
-					int workspaceArtifactId = QueryForWorkspaceArtifactId(workspaceName, rsapiClient);
-					Console.WriteLine("Queried for Workspace Artifact Id");
+				int workspaceId = await WorkspaceHelper.GetFirstWorkspaceArtifactIdQueryAsync(workspaceName);
+				int smokeTestObjectTypeId = await GetSmokeTestObjectTypeIdAsync(workspaceId);
 
-					rsapiClient.APIOptions.WorkspaceID = workspaceArtifactId;
-					while (currentWaitTimeInMilliseconds < maxTimeInMilliseconds && completed == false)
-					{
-						Thread.Sleep(sleepTimeInMilliSeconds);
+				HttpResponseMessage queryResponse = await QueryForSmokeTestRdos(workspaceId, smokeTestObjectTypeId);
 
-						Console.WriteLine("Querying for Smoke Test RDOs");
-						var queryResultSet = QueryForTestRDOs(rsapiClient);
-						Console.WriteLine("Queried for Smoke Test RDOs");
+				string resultString = await queryResponse.Content.ReadAsStringAsync();
+				dynamic result = JObject.Parse(resultString) as JObject;
+				//objectTypeId = result.Objects[0]["Values"][1];
 
-						int numberSuccess = 0;
-						int numberFail = 0;
-						foreach (Result<RDO> result in queryResultSet.Results)
-						{
-							string status = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)).ValueAsFixedLengthText;
-							if (status.Contains("Success"))
-							{
-								numberSuccess++;
-							}
-							if (status.Contains("Fail"))
-							{
-								numberFail++;
-								hasFailingTests = true;
-								completed = true;
-								string testName = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)).ValueAsFixedLengthText;
-								string errorDetails = result.Artifact.Fields.Get(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText)).ValueAsLongText;
-								Console.WriteLine($"Failing Test Found: {testName}");
-								Console.WriteLine($"Error Details: {errorDetails}");
-								break;
-							}
-						}
+				var test = result.Objects;
 
-						if (queryResultSet.Results.Count > 0)
-						{
-							if ((numberSuccess + numberFail) == queryResultSet.Results.Count)
-							{
-								completed = true;
-							}
-						}
-
-						currentWaitTimeInMilliseconds += sleepTimeInMilliSeconds;
-					}
-				}
-
-				return completed && !hasFailingTests;
+				return test != null;
 			}
 			catch (Exception ex)
 			{
@@ -84,39 +116,105 @@ namespace Helpers.Implementations
 			}
 		}
 
-		private static int QueryForWorkspaceArtifactId(string workspaceName, IRSAPIClient rsapiClient)
+		private async Task<int> GetSmokeTestObjectTypeIdAsync(int workspaceId)
 		{
-			Query<Workspace> workspaceQuery = new Query<Workspace>();
-			workspaceQuery.Condition = new TextCondition(WorkspaceFieldNames.Name, TextConditionEnum.EqualTo, workspaceName);
-			QueryResultSet<Workspace> workspaceQueryResultSet = rsapiClient.Repositories.Workspace.Query(workspaceQuery);
-			if (!workspaceQueryResultSet.Success)
+			int objectTypeId;
+			try
 			{
-				throw new Exception("Failed to Query for Workspace");
+				string url = Constants.Connection.RestUrlEndpoints.ObjectManager.QuerySlimUrl.Replace("-1", workspaceId.ToString());
+				HttpClient httpClient = RestHelper.GetHttpClient(InstanceAddress, AdminUsername, AdminPassword);
+				var queryPayloadObject = new
+				{
+					request = new
+					{
+						objectType = new { artifactTypeId = Constants.OBJECT_TYPE_TYPE_ARTIFACT_ID },
+						fields = new[]
+						{
+							new { Name = "Name" },
+							new { Name = "Artifact Type ID" },
+						},
+						Condition = $"'Name' == '{Constants.SmokeTest.ObjectNames.SmokeTestApplicationObjectTypeName}'",
+					},
+					start = 1,
+					length = 25
+				};
+
+				string queryPayload = JsonConvert.SerializeObject(queryPayloadObject);
+				HttpResponseMessage queryResponse = await RestHelper.MakePostAsync(httpClient, url, queryPayload);
+				if (!queryResponse.IsSuccessStatusCode)
+				{
+					throw new Exception("Failed to Query for Smoke Test Object Type");
+				}
+
+				string resultString = await queryResponse.Content.ReadAsStringAsync();
+				//dynamic result = JObject.Parse(resultString) as JObject;
+				dynamic queryResult = JsonConvert.DeserializeObject<dynamic>(resultString);
+				//objectTypeId = result.Objects[0]["ArtifactID"];
+				objectTypeId = queryResult.Objects.First.ArtifactID;
+			}
+			catch (Exception ex)
+			{
+				throw new Exception(
+					$"Error Reading the {Constants.SmokeTest.ObjectNames.SmokeTestApplicationName} ObjectType", ex);
 			}
 
-			int workspaceArtifactId = workspaceQueryResultSet.Results.First().Artifact.ArtifactID;
-			return workspaceArtifactId;
+			return objectTypeId;
 		}
 
-		private static QueryResultSet<RDO> QueryForTestRDOs(IRSAPIClient rsapiClient)
+		//private QueryResultSet<RDO> QueryForTestRDOs(int workspaceArtifactId)
+		//{
+		//	Query<RDO> query = new Query<RDO>();
+		//	query.ArtifactTypeGuid = new Guid(Constants.SmokeTest.Guids.TestObjectType);
+		//	query.Fields = new List<FieldValue>
+		//	{
+		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)),
+		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)),
+		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Error_LongText)),
+		//		new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText))
+		//	};
+
+		//	QueryResultSet<RDO> queryResultSet = rsapiClient.Repositories.RDO.Query(query);
+		//	if (!queryResultSet.Success)
+		//	{
+		//		throw new Exception("Unable to query for Smoke Test Test Objects");
+		//	}
+
+		//	return queryResultSet;
+		//}
+
+		private async Task<HttpResponseMessage> QueryForSmokeTestRdos(int workspaceId, int smokeTestObjectTypeId)
 		{
-			Query<RDO> query = new Query<RDO>();
-			query.ArtifactTypeGuid = new Guid(Constants.SmokeTest.Guids.TestObjectType);
-			query.Fields = new List<FieldValue>
+			string url = Constants.Connection.RestUrlEndpoints.ObjectManager.QuerySlimUrl.Replace("-1", workspaceId.ToString());
+			HttpClient httpClient = RestHelper.GetHttpClient(InstanceAddress, AdminUsername, AdminPassword);
+
+			var queryPayloadObject = new
 			{
-				new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Name_FixedLengthText)),
-				new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Status_FixedLengthText)),
-				new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.Error_LongText)),
-				new FieldValue(new Guid(Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText))
+				request = new
+				{
+					objectType = new { Guid = Constants.SmokeTest.Guids.TestObjectType },
+					//objectType = new { artifactTypeId = Constants.OBJECT_TYPE_TYPE_ARTIFACT_ID },
+					//objectType = new { artifactTypeId = smokeTestObjectTypeId },
+					fields = new[]
+					{
+						//new { Name = "Name" },
+						new { Guid = Constants.SmokeTest.Guids.Fields.Name_FixedLengthText },
+						new { Guid = Constants.SmokeTest.Guids.Fields.Status_FixedLengthText },
+						new { Guid = Constants.SmokeTest.Guids.Fields.Error_LongText },
+						new { Guid = Constants.SmokeTest.Guids.Fields.ErrorDetails_LongText },
+					},
+				},
+				start = 1,
+				length = 25
 			};
 
-			QueryResultSet<RDO> queryResultSet = rsapiClient.Repositories.RDO.Query(query);
-			if (!queryResultSet.Success)
+			string queryPayload = JsonConvert.SerializeObject(queryPayloadObject);
+			HttpResponseMessage queryResponse = await RestHelper.MakePostAsync(httpClient, url, queryPayload);
+			if (!queryResponse.IsSuccessStatusCode)
 			{
-				throw new Exception("Unable to query for Smoke Test Test Objects");
+				throw new Exception("Failed to Query for Smoke Test RDO");
 			}
 
-			return queryResultSet;
+			return queryResponse;
 		}
 	}
 }

--- a/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
+++ b/CSharp/DevVmPowershell/Helpers/Implementations/SmokeTestHelper.cs
@@ -33,10 +33,10 @@ namespace Helpers.Implementations
 			try
 			{
 				int workspaceId = await WorkspaceHelper.GetFirstWorkspaceArtifactIdQueryAsync(workspaceName);
-				int smokeTestObjectTypeId = await RetryLogicHelper.RetryFunctionAsync<int>(2, 30,
+				int smokeTestObjectTypeId = await RetryLogicHelper.RetryFunctionAsync<int>(Constants.Waiting.SMOKE_TEST_HELPER_RETRY_COUNT, Constants.Waiting.SMOKE_TEST_HELPER_SLEEP_TIME_IN_SECONDS,
 					async () => await GetSmokeTestObjectTypeIdAsync(workspaceId));
 
-				bool didTestsComplete = await RetryLogicHelper.RetryFunctionAsync<bool>(10, timeoutValueInMinutes * 60,
+				bool didTestsComplete = await RetryLogicHelper.RetryFunctionAsync<bool>(Constants.Waiting.SMOKE_TEST_HELPER_RETRY_COUNT, timeoutValueInMinutes * 60,
 					async () =>
 					{
 						HttpResponseMessage queryResponse = await QueryForSmokeTestRdosAsync(workspaceId, smokeTestObjectTypeId);
@@ -121,9 +121,7 @@ namespace Helpers.Implementations
 				}
 
 				string resultString = await queryResponse.Content.ReadAsStringAsync();
-				//dynamic result = JObject.Parse(resultString) as JObject;
 				dynamic queryResult = JsonConvert.DeserializeObject<dynamic>(resultString);
-				//objectTypeId = result.Objects[0]["ArtifactID"];
 				objectTypeId = queryResult.Objects.First.ArtifactID;
 			}
 			catch (Exception ex)

--- a/CSharp/DevVmPowershell/Helpers/Interfaces/ISmokeTestHelper.cs
+++ b/CSharp/DevVmPowershell/Helpers/Interfaces/ISmokeTestHelper.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Helpers.Interfaces
 {
 	public interface ISmokeTestHelper
 	{
-		bool WaitForSmokeTestToComplete(string workspaceName, int timeoutValueInMinutes);
+		Task<bool> WaitForSmokeTestToCompleteAsync(string workspaceName, int timeoutValueInMinutes);
 	}
 }


### PR DESCRIPTION
Smoke Test Imaging tests kept failing on my DevVM but I believe it was because of my DevVM just being in a bad state.  I've switched to a 12.0 and that passed quickly but...

2 tests still fail, but I believe they are because of the RAP and not the helper (the subject of this PR)
Processing - An error occured in Processing Test. ErrorMessage: Processing is not installed in this workspace.

Data Grid - An error occured in Data Grid Test. ErrorMessage: Data Grid is not enabled on the extracted text field